### PR TITLE
Improve GitHub Actions configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: "07:15"
+      timezone: "Europe/London"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@master
+        uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 


### PR DESCRIPTION
- Get Dependabot to check for GitHub Actions updates
- Switch GitHub Actions to use tags where possible